### PR TITLE
chore: add keep-alive job to prevent Supabase DB auto-pausing

### DIFF
--- a/src/app/api/inngest/route.js
+++ b/src/app/api/inngest/route.js
@@ -6,6 +6,7 @@ import {
 	generateMonthlyReports,
 	processRecurringTransaction,
 	triggerRecurringTransactions,
+	pingSupabase,
 } from '@/lib/inngest/functions';
 
 export const { GET, POST, PUT } = serve({
@@ -15,5 +16,6 @@ export const { GET, POST, PUT } = serve({
 		triggerRecurringTransactions,
 		generateMonthlyReports,
 		checkBudgetAlerts,
+		pingSupabase,
 	],
 });


### PR DESCRIPTION
- Scheduled a periodic ping every 7 days
- Ensures Supabase stays active for Finflow AI
- No user-facing changes